### PR TITLE
Support standard syslog UDP/514

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ export log4js_syslog_appender_whitelist=audit-logs,audit-logs-v2
 export log4js_syslog_appender_host=syslog.prd.ccs.ibmcloud.com
 export log4js_syslog_appender_port=6514
 export log4js_syslog_appender_product=otc-api
+```
+
+##Use with default syslog
+
+You can use this appender with any default UDP syslog in unencrypted mode.  The environment setup is very similar to above:
+
+```
+export log4js_syslog_appender_enabled=true
+export log4js_syslog_appender_useUdpSyslog=true
+export log4js_syslog_appender_whitelist=audit-logs,audit-logs-v2
+export log4js_syslog_appender_host=localhost
+export log4js_syslog_appender_port=514
+export log4js_syslog_appender_product=otc-api
+```
+
 
 # Setting Certificates
 There are two ways of setting the certs, either through a path (meaning you have to check it into a source control - kind of a nono or by setting the base64 encoded values as env vars - the right way).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log4js-qradar-syslog-appender",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The appender can now support the standard unencrypted default
syslog port UDP/514.  You need to set the following
environment variables.

log4js_syslog_appender_enabled
log4js_syslog_appender_useUdpSyslog
log4js_syslog_appender_host
log4js_syslog_appender_port # usually 514
log4js_syslog_appender_product

It still respects log4js_syslog_appender_whitelist
